### PR TITLE
Fix default docker compose project name

### DIFF
--- a/ComposeTestEnvironment.xUnit/DockerComposeDescriptor.cs
+++ b/ComposeTestEnvironment.xUnit/DockerComposeDescriptor.cs
@@ -23,7 +23,7 @@ namespace ComposeTestEnvironment.xUnit
         /// docker-compose project name.
         /// </summary>
         public virtual string ProjectName
-            => GetType().Assembly?.GetName().Name ?? throw new NotSupportedException($"Null assembly is not supported (typeof({GetType().Name}).Assembly)");
+            => GetType().Assembly?.GetName().Name.ToLowerInvariant() ?? throw new NotSupportedException($"Null assembly is not supported (typeof({GetType().Name}).Assembly)");
 
         /// <summary>
         /// Timeout to start environment.


### PR DESCRIPTION
See https://github.com/docker/compose/issues/9378
Since 2.4.0, docker compose requires project name to be lowercase.